### PR TITLE
Add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - persist_to_workspace:
           root: /go/bin
           paths:
-            - *
+            - boxctl
   deploy:
     docker:
       - image: google/cloud-sdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,16 +10,22 @@ jobs:
       - run: go get -v -t -d ./...
       - run: go install github.com/tangentspace/ghostbox/cmd/boxctl
       - run: ls -lh /go/bin
+      - persist_to_workspace:
+          root: /go/bin
+          paths:
+            - *
   deploy:
     docker:
       - image: google/cloud-sdk
     steps:
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
           name: Store Service Account
           command: echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
       - run: |
           gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
-          gsutil cp /go/bin/* gs://ghostbox/artifacts/circleci/builds/${CIRCLE_BUILD_NUM}/
+          gsutil cp /tmp/workspace/* gs://ghostbox/artifacts/circleci/builds/${CIRCLE_BUILD_NUM}/
 workflows:
   version: 2
   build-and-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,15 @@ jobs:
       - run: go get -v -t -d ./...
       - run: go install github.com/tangentspace/ghostbox/cmd/boxctl
       - run: ls -lh /go/bin
+  deploy:
+    docker:
+      - image: google/cloud-sdk
+    steps:
+      - run:
+          name: Store Service Account
+          command: echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
+      - run: |
+          sudo gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
 workflows:
   version: 2
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,9 @@ jobs:
           gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
 workflows:
   version: 2
-  build_and_test:
+  build-and-deploy:
     jobs:
       - build
-      - deploy
+      - deploy:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,8 @@ jobs:
       - run:
           name: Store Service Account
           command: echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
-      - run: |
-          gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
-          gsutil cp /tmp/workspace/* gs://ghostbox/artifacts/circleci/builds/${CIRCLE_BUILD_NUM}/
+      - run: gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
+      - run: gsutil cp /tmp/workspace/* gs://ghostbox/artifacts/circleci/builds/${CIRCLE_BUILD_NUM}/
 workflows:
   version: 2
   build-and-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,3 +24,4 @@ workflows:
   build_and_test:
     jobs:
       - build
+      - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,13 @@
 version: 2
 jobs:
   build:
-    environment:
-      - GOPATH: /go
-      - GOBIN: /go/bin
+    working_directory: /go/src/github.com/tangentspace/ghostbox
     docker:
       - image: circleci/golang:1.10.0
     steps:
       - checkout
       - run: go env
+      - run: go get -v -t -d ./...
       - run: go install github.com/tangentspace/ghostbox/cmd/boxctl
       - run: ls -lh ${GOBIN}
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2
+jobs:
+  build:
+    environment:
+      - GOPATH: /go
+      - GOBIN: /go/bin
+    docker:
+      - image: circleci/golang:1.10.0
+    steps:
+      - checkout
+      - run: go env
+      - run: go install github.com/tangentspace/ghostbox/cmd/boxctl
+      - run: ls -lh ${GOBIN}
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           name: Store Service Account
           command: echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
       - run: |
-          sudo gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
+          gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
 workflows:
   version: 2
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run: go env
       - run: go get -v -t -d ./...
       - run: go install github.com/tangentspace/ghostbox/cmd/boxctl
-      - run: ls -lh ${GOBIN}
+      - run: ls -lh /go/bin
 workflows:
   version: 2
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
           command: echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
       - run: |
           gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
+          gsutil cp /go/bin/* gs://ghostbox/artifacts/circleci/builds/${CIRCLE_BUILD_NUM}/
 workflows:
   version: 2
   build-and-deploy:


### PR DESCRIPTION
Add configuration file for CircleCI to create a simple workflow that
1. builds boxctl for Linux
2. pushed to ghostbox GCS bucket

Artifacts are stored for each build using the following naming scheme:
/artifacts/circleci/builds/${CIRCLE_BUILD_NUM}/boxctl